### PR TITLE
fix: verify author of each individual commit

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,13 @@
+name: Check CLA
+on:
+  - pull_request
+
+jobs:
+  check-cla:
+    runs-on: ubuntu-latest
+    name: Verify contributor
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Verify CLA
+      uses: ./

--- a/index.js
+++ b/index.js
@@ -17,10 +17,12 @@ const body = await new Promise((resolve, reject) => {
 	});
 });
 
-const signedUsers = body
+const signedUsers = [...body
 	.match(/^\|.+\|$/mg)
 	?.slice(2)
-	.map(u => u.split('|')[2].trim());
+	.map(u => u.split('|')[2].trim()),
+	'dependabot[bot]'
+];
 
 const pr = await gh.rest.pulls.listCommits({
 	owner: context.repo.owner,

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "maintainers": [
     "Chris Barber <chris@cb1inc.com>"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@actions/github": "^5.0.1"
+  }
 }


### PR DESCRIPTION
The GITHUB_USER environment variable does not always refer to the author of a PR, if that PR has to be approved before being ran, or the CLA check has been reran then it will point to the user who triggered that. By retrieving all commits and then inspecting each on this is a more correct way to check the validity

You can see some examples of this [here](https://github.com/tidev/titanium_mobile/runs/6342018068?check_suite_focus=true) (authorized by miga), and [here](https://github.com/tidev/vscode-titanium/runs/6313619138?check_suite_focus=true) (CLA check was reran by me)